### PR TITLE
Improve OptimizedSolver, use pieces as hash key

### DIFF
--- a/pentomino-solver/src/bitboard.rs
+++ b/pentomino-solver/src/bitboard.rs
@@ -6,6 +6,7 @@ use derive_more::{BitAnd, BitAndAssign, BitOr, BitOrAssign, From, Into};
     Copy,
     PartialEq,
     Eq,
+    Hash,
     Default,
     // From/Into, and bit manipulations by derive_more
     From,


### PR DESCRIPTION
before: #2 

after:
```
test bench_3x20_optimized           ... bench:     200,705 ns/iter (+/- 10,797)
test bench_3x20_optimized_unique    ... bench:     198,053 ns/iter (+/- 5,818)
test bench_4x15_optimized           ... bench:   4,885,066 ns/iter (+/- 859,894)
test bench_4x15_optimized_unique    ... bench:   4,581,341 ns/iter (+/- 1,451,962)
test bench_5x12_optimized           ... bench:  25,122,333 ns/iter (+/- 3,643,952)
test bench_5x12_optimized_unique    ... bench:  23,692,666 ns/iter (+/- 2,720,265)
test bench_6x10_optimized           ... bench:  61,437,370 ns/iter (+/- 4,026,847)
test bench_6x10_optimized_unique    ... bench:  59,592,208 ns/iter (+/- 5,773,675)
test bench_8x8_2x2_optimized        ... bench:  13,205,620 ns/iter (+/- 292,175)
test bench_8x8_2x2_optimized_unique ... bench:  13,134,995 ns/iter (+/- 311,008)
```