### PR TITLE
Improve OptimizedSolver, add hole-checking to next rows

### DIFF
--- a/pentomino-solver/src/solvers/optimized.rs
+++ b/pentomino-solver/src/solvers/optimized.rs
@@ -91,7 +91,7 @@ pub struct OptimizedSolver {
     transposed: bool,
     table: [Vec<Vec<(usize, Bitboard)>>; 64],
     xs: Vec<Bitboard>,
-    halls: [(Bitboard, Bitboard); 64],
+    holes: [(Bitboard, Bitboard); 64],
 }
 
 impl OptimizedSolver {
@@ -133,7 +133,7 @@ impl OptimizedSolver {
         }
         let x_swaps = Self::generate_swaps((0..rows).map(|i| 1 << (cols * i)).sum(), cols, 1);
         let y_swaps = Self::generate_swaps((0..cols).map(|i| 1 << i).sum(), rows, cols);
-        let mut halls = [(Bitboard::default(), Bitboard::from(!0)); 64];
+        let mut holes = [(Bitboard::default(), Bitboard::from(!0)); 64];
         for y in 0..rows {
             for x in 0..cols {
                 let z = x + y * cols;
@@ -147,9 +147,9 @@ impl OptimizedSolver {
                 }
                 let (mask, check) = ((v | (1 << z)).into(), v.into());
                 if y > 0 && x < cols - 1 {
-                    halls[(x + 1) + (y - 1) * cols] = (mask, check);
+                    holes[(x + 1) + (y - 1) * cols] = (mask, check);
                     if x == 0 {
-                        halls[x + (y - 1) * cols] = (mask, check);
+                        holes[x + (y - 1) * cols] = (mask, check);
                     }
                 }
             }
@@ -162,7 +162,7 @@ impl OptimizedSolver {
             xs,
             x_swaps,
             y_swaps,
-            halls,
+            holes,
         }
     }
     fn backtrack(&self, current: Bitboard, remain: usize, state: &mut SolutionState) {
@@ -173,7 +173,7 @@ impl OptimizedSolver {
         for &(i, b) in &self.table[target][remain] {
             if (current & b).is_empty() {
                 let next = current | b;
-                if next & self.halls[target].0 == self.halls[target].1 {
+                if next & self.holes[target].0 == self.holes[target].1 {
                     continue;
                 }
                 state.pieces[i] = b;


### PR DESCRIPTION
before: #3 

after:
```
test bench_3x20_optimized           ... bench:     173,366 ns/iter (+/- 6,275)
test bench_3x20_optimized_unique    ... bench:     174,413 ns/iter (+/- 1,875)
test bench_4x15_optimized           ... bench:   3,832,441 ns/iter (+/- 87,397)
test bench_4x15_optimized_unique    ... bench:   3,778,514 ns/iter (+/- 15,767)
test bench_5x12_optimized           ... bench:  20,870,829 ns/iter (+/- 2,242,749)
test bench_5x12_optimized_unique    ... bench:  20,367,612 ns/iter (+/- 3,486,165)
test bench_6x10_optimized           ... bench:  52,428,358 ns/iter (+/- 1,345,515)
test bench_6x10_optimized_unique    ... bench:  50,954,129 ns/iter (+/- 665,904)
test bench_8x8_2x2_optimized        ... bench:  11,657,095 ns/iter (+/- 126,585)
test bench_8x8_2x2_optimized_unique ... bench:  11,554,141 ns/iter (+/- 903,395)
```