### PR TITLE
Reject `--solver simple --unique` instead of panicking

### DIFF
--- a/pentomino-solver-cli/src/bin/main.rs
+++ b/pentomino-solver-cli/src/bin/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, ValueEnum};
+use clap::{CommandFactory, Parser, ValueEnum};
 use colored::*;
 use pentomino_solver::solvers::OptimizedSolverType;
 use pentomino_solver::solvers::{DefaultSolver, OptimizedSolver, SimpleSolver};
@@ -96,6 +96,15 @@ fn output(piece: &Option<Piece>, color: bool) -> String {
 
 fn main() {
     let args = Args::parse();
+
+    if args.unique && matches!(args.solver, Solver::Simple) {
+        Args::command()
+            .error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "--unique is not supported by --solver simple",
+            )
+            .exit();
+    }
 
     let ((rows, cols), initial) = match args.board {
         Board::Rect3x20 => ((3, 20), 0),


### PR DESCRIPTION
## Summary

Running the CLI with `--solver simple --unique` propagated the `panic!` inside
`SimpleSolver::solve` ("SimpleSolver does not support unique solutions") all the
way to the user as an unhandled panic (exit 101).

clap accepts the flag combination, so this adds a check right after argument
parsing and surfaces it as a normal clap error (`ArgumentConflict`, exit 2)
instead.

## Behavior change

Before:
```
thread 'main' panicked at pentomino-solver/src/solvers/simple.rs:64:13:
SimpleSolver does not support unique solutions
```

After:
```
error: --unique is not supported by --solver simple

Usage: pentomino-solver-cli [OPTIONS]

For more information, try '--help'.
```

## Notes

- The library-side `panic!` is left in place: it documents the intentional
  contract that `SimpleSolver` does not support unique solutions. The guard only
  lives at the CLI boundary.
- Verified that `simple` (without `--unique`) and every other solver with
  `--unique` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)